### PR TITLE
Fix the case all inputs to BroadcastableCallable are constants

### DIFF
--- a/src/ChainCutters.jl
+++ b/src/ChainCutters.jl
@@ -165,7 +165,8 @@ function dual_function(f::F, args0::NTuple{N, Any}) where {F, N}
     end
 end
 
-broadcast_adjoint(f, args::Vararg{Const}) = f.(args...), _ -> nothing
+broadcast_adjoint(f, args::Vararg{Const}) =
+    f.(map(unwrap, args)...), _ -> nothing
 
 function broadcast_adjoint(f, args0...)
     args = map(unwrap, args0)
@@ -193,7 +194,9 @@ using BroadcastableStructs: BroadcastableCallable, calling, splitargsfor
         args...,
     )
     function broadcastablecallable_pullback(Δ)
-        fields, rest = splitargsfor(obj, Base.tail(back(Δ))...)
+        partials = back(Δ)
+        partials === nothing && return nothing
+        fields, rest = splitargsfor(obj, Base.tail(partials)...)
         return (NamedTuple{__fieldnames(obj)}(fields), rest...)
     end
     return y, broadcastablecallable_pullback

--- a/test/test_broadcastablecallable.jl
+++ b/test/test_broadcastablecallable.jl
@@ -44,6 +44,16 @@ end
     end
     @test y_actual == y_desired
     @test back_actual(1) == back_desired(1)
+
+    @testset "all constants" begin
+        function h(a)
+            g = cut(@set f.a = a)
+            sum(g.(cut(u), cut(v)))
+        end
+        y_actual, back_actual = Zygote.forward(h, f.a)
+        @test y_actual == h(f.a)
+        @test back_actual(1) == (nothing,)
+    end
 end
 
 end  # module


### PR DESCRIPTION
From xfail https://travis-ci.com/tkf/ChainCutters.jl/jobs/237046571 :

```
  MethodError: no method matching length(::ChainCutters.Const{Float64})
  Closest candidates are:
    length(!Matched::Core.SimpleVector) at essentials.jl:597
    length(!Matched::Base.MethodList) at reflection.jl:819
    length(!Matched::Core.MethodTable) at reflection.jl:893
    ...
  Stacktrace:
   [1] _similar_for(::UnitRange{Int64}, ::Type{Any}, ::ChainCutters.Const{Float64}, ::Base.HasLength) at ./array.jl:517
   [2] _collect(::UnitRange{Int64}, ::ChainCutters.Const{Float64}, ::Base.HasEltype, ::Base.HasLength) at ./array.jl:550
   [3] collect(::ChainCutters.Const{Float64}) at ./array.jl:544
   [4] broadcastable(::ChainCutters.Const{Float64}) at ./broadcast.jl:659
   [5] broadcasted(::Function, ::ChainCutters.Const{Float64}, ::ChainCutters.Const{Float64}, ::ChainCutters.Const{Array{Float64,1}}, ::ChainCutters.Const{Array{Float64,1}}) at ./broadcast.jl:1213
   [6] broadcast_adjoint(::Function, ::ChainCutters.Const{Float64}, ::Vararg{ChainCutters.Const,N} where N) at /home/travis/build/tkf/ChainCutters.jl/src/ChainCutters.jl:168
   [7] adjoint at /home/travis/build/tkf/ChainCutters.jl/src/ChainCutters.jl:190 [inlined]
   [8] _forward at /home/travis/.julia/packages/ZygoteRules/Jn4LO/src/adjoint.jl:46 [inlined]
   [9] h at /home/travis/build/tkf/ChainCutters.jl/test/test_broadcastablecallable.jl:51 [inlined]
   [10] _forward(::Zygote.Context, ::getfield(Main.TestChainCutters.TestBroadcastableCallable, Symbol("#h#5")){Main.TestChainCutters.TestBroadcastableCallable.WeightedAdd{Float64,Float64},Array{Float64,1},Array{Float64,1}}, ::Float64) at /home/travis/.julia/packages/Zygote/bdE6T/src/compiler/interface2.jl:0
...
```