### PR TITLE
Define adjoint of unwrap

### DIFF
--- a/src/ChainCutters.jl
+++ b/src/ChainCutters.jl
@@ -95,6 +95,7 @@ Base.setindex(x::Variable, I...) = _uncut(Base.setindex(unwrap(x), I...))
 @inline unwrap_rec(x::Wrapper) = unwrap_rec(unwrap(x))
 @inline unwrap_rec(x::Union{Tuple, NamedTuple}) = map(unwrap_rec, x)
 
+@adjoint unwrap(x) = unwrap(x), y -> (y,)
 @adjoint cut(x) = _cut(x), y -> (y,)  # not `nothing`
 @adjoint uncut(x) = _uncut(x), y -> (y,)
 # Note:


### PR DESCRIPTION
It looks like Zygote interpret `getfield` as `literal_getproperty`. So the adjoint has to be defined for it to really call `getfield`.